### PR TITLE
Add configuration for hook log output

### DIFF
--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -19,6 +19,7 @@ package action
 import (
 	"bytes"
 	"fmt"
+	"io"
 	"os"
 	"path"
 	"path/filepath"
@@ -93,6 +94,9 @@ type Configuration struct {
 
 	// Capabilities describes the capabilities of the Kubernetes cluster.
 	Capabilities *chartutil.Capabilities
+
+	// Called with container name and returns and expects writer that will receive the log output
+	HookOutputFunc func(namespace string, pod string, container string) io.Writer
 
 	Log func(string, ...interface{})
 }
@@ -421,6 +425,11 @@ func (cfg *Configuration) Init(getter genericclioptions.RESTClientGetter, namesp
 	cfg.KubeClient = kc
 	cfg.Releases = store
 	cfg.Log = log
+
+	cfg.HookOutputFunc = func(namespace string, pod string, container string) io.Writer {
+		fmt.Fprint(os.Stdout, fmt.Sprintf("Logs for pod: %s, container: %s:\n", pod, container))
+		return os.Stdout
+	}
 
 	return nil
 }

--- a/pkg/action/hooks.go
+++ b/pkg/action/hooks.go
@@ -196,7 +196,8 @@ func (cfg *Configuration) outputContainerLogsForListOptions(namespace string, li
 		if err != nil {
 			return err
 		}
-		err = kubeClient.OutputContainerLogsForPodList(podList, namespace, log.Writer())
+		logWriterFunc := cfg.HookOutputFunc
+		err = kubeClient.OutputContainerLogsForPodList(podList, namespace, logWriterFunc)
 		return err
 	}
 	return nil

--- a/pkg/kube/client.go
+++ b/pkg/kube/client.go
@@ -808,13 +808,14 @@ func (c *Client) GetPodList(namespace string, listOptions metav1.ListOptions) (*
 }
 
 // OutputContainerLogsForPodList is a helper that outputs logs for a list of pods
-func (c *Client) OutputContainerLogsForPodList(podList *v1.PodList, namespace string, writer io.Writer) error {
+func (c *Client) OutputContainerLogsForPodList(podList *v1.PodList, namespace string, writerFunc func(string, string, string) io.Writer) error {
 	for _, pod := range podList.Items {
 		for _, container := range pod.Spec.Containers {
 			options := &v1.PodLogOptions{
 				Container: container.Name,
 			}
 			request := c.kubeClient.CoreV1().Pods(namespace).GetLogs(pod.Name, options)
+			writer := writerFunc(pod.Namespace, pod.Name, container.Name)
 			err2 := copyRequestStreamToWriter(request, pod.Name, container.Name, writer)
 			if err2 != nil {
 				return err2

--- a/pkg/kube/client_test.go
+++ b/pkg/kube/client_test.go
@@ -410,7 +410,7 @@ func TestOutputContainerLogsForPodList(t *testing.T) {
 	kubeClient := k8sfake.NewSimpleClientset(&somePodList)
 	c := Client{Namespace: namespace, kubeClient: kubeClient}
 	outBuffer := &bytes.Buffer{}
-	err := c.OutputContainerLogsForPodList(&somePodList, namespace, outBuffer)
+	err := c.OutputContainerLogsForPodList(&somePodList, namespace, func(string, string, string) io.Writer { return outBuffer })
 	clientAssertions := assert.New(t)
 	clientAssertions.NoError(err)
 	clientAssertions.Equal("fake logsfake logsfake logs", outBuffer.String())

--- a/pkg/kube/interface.go
+++ b/pkg/kube/interface.go
@@ -83,7 +83,7 @@ type InterfaceExt interface {
 	GetPodList(namespace string, listOptions metav1.ListOptions) (*v1.PodList, error)
 
 	// OutputContainerLogsForPodList output the logs for a pod list
-	OutputContainerLogsForPodList(podList *v1.PodList, namespace string, writer io.Writer) error
+	OutputContainerLogsForPodList(podList *v1.PodList, namespace string, writerFunc func(namespace string, pod string, container string) io.Writer) error
 }
 
 // InterfaceDeletionPropagation is introduced to avoid breaking backwards compatibility for Interface implementers.


### PR DESCRIPTION
Add the ability for SDK clients to specify a function that will generate IOWriters so that they can parse receive hook job output that has been indicated as important